### PR TITLE
Fix multi frame responses

### DIFF
--- a/transport-ble/src/main/java/com/ledger/live/ble/service/BleServiceStateMachine.kt
+++ b/transport-ble/src/main/java/com/ledger/live/ble/service/BleServiceStateMachine.kt
@@ -59,16 +59,9 @@ class BleServiceStateMachine(
     private fun handleGattCallbackEvent(event: GattCallbackEvent) {
         when (event) {
             is GattCallbackEvent.ConnectionState.Connected -> {
-                when(currentState) {
-                    BleServiceState.Created -> {
-                        timeoutJob.cancel()
-                        gattInteractor.discoverService()
-                        pushState(BleServiceState.WaitingServices)
-                    }
-                    else -> {
-                        pushState(BleServiceState.Error("Connected event should only be received when current state is Created"))
-                    }
-                }
+                timeoutJob.cancel()
+                gattInteractor.discoverService()
+                pushState(BleServiceState.WaitingServices)
             }
             is GattCallbackEvent.ServicesDiscovered -> {
                 val deviceService = parseServices(event.services)
@@ -77,15 +70,8 @@ class BleServiceStateMachine(
                     Timber.d("Current State $currentState")
 
                     this@BleServiceStateMachine.deviceService = deviceService
-                    when(currentState) {
-                        BleServiceState.WaitingServices -> {
-                            gattInteractor.enableNotification(deviceService)
-                            pushState(BleServiceState.WaitingNotificationEnable)
-                        }
-                        else -> {
-                            pushState(BleServiceState.Error("Connected event should only be received when current state is Created"))
-                        }
-                    }
+                    gattInteractor.enableNotification(deviceService)
+                    pushState(BleServiceState.WaitingNotificationEnable)
                 }
             }
             is GattCallbackEvent.WriteDescriptorAck -> {

--- a/transport-ble/src/main/java/com/ledger/live/ble/service/BleServiceStateMachine.kt
+++ b/transport-ble/src/main/java/com/ledger/live/ble/service/BleServiceStateMachine.kt
@@ -125,8 +125,12 @@ class BleServiceStateMachine(
                     }
                     is BleServiceState.WaitingResponse -> {
                         val answer = bleReceiver.handleAnswer(bleSender.pendingCommand!!.id, event.value.toHexString())
-                        bleSender.clearCommand()
-                        pushState(BleServiceState.Ready(deviceService, mtuSize, answer))
+                        if (answer != null) {
+                            bleSender.clearCommand()
+                            pushState(BleServiceState.Ready(deviceService, mtuSize, answer))
+                        } else {
+                            Timber.d("Still waiting for a part of the answer")
+                        }
                     }
                     else -> {
                         pushState(BleServiceState.Error("CharacteristicChanged event should only be received when current state is WaitingMtu or WaitingResponse"))


### PR DESCRIPTION
With the context from the slack channel. Multi frame responses were returning `null` from the Ble Receiver, setting the state machine incorrectly to Ready and breaking when we received the last byte from the response. This addresses that.